### PR TITLE
Update ril.h

### DIFF
--- a/include/telephony/ril.h
+++ b/include/telephony/ril.h
@@ -2172,7 +2172,9 @@ typedef struct {
  *  RADIO_NOT_AVAILABLE
  *  ILLEGAL_SIM_OR_ME
  *  GENERIC_FAILURE
- *
+ *  CSG_UNAUTHORIZED
+ *  ATTACH_TEMP_BARRED
+ * 
  * Note: Returns ILLEGAL_SIM_OR_ME when the failure is permanent and
  *       no retries needed, such as illegal SIM or ME.
  *       Returns GENERIC_FAILURE for all other causes that might be


### PR DESCRIPTION
Network attach should handle this errors 
"CSG_UNAUTHORIZED
ATTACH_TEMP_BARRED"
as they add more to the user interactions as why the registration failed.
Correspondingly we need to handle in the Telephony framework
